### PR TITLE
Configurated to generate html reports instead of text in composer.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Thumbs.db
 
 tmp
+coverage-report
 
 vendor
 

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,6 @@
             "@phpstan",
             "php-cs-fixer"
         ],
-        "phpunit": "vendor\\bin\\phpunit --coverage-text"
+        "phpunit": "vendor\\bin\\phpunit --coverage-html coverage-report"
     }
 }


### PR DESCRIPTION
The script :
_"phpunit": "vendor\\bin\\phpunit --coverage-text"_
Has been changed into :
_"phpunit": "vendor\\bin\\phpunit --coverage-html coverage-report"_

Inside the root folder, we’ll create a new folder called coverage-report. The first time you run the script, this folder will be created. On every subsequent run, the contents of this folder will be overwritten with the latest coverage data. **This was done to ensure a more in-depth view of the test coverage of the project.**

A .gitignore line added to not upload the coverage report into the repository.

(Open index.html to see this view.)
![image](https://github.com/user-attachments/assets/c029e89a-2413-4927-9c60-85f941131f24)
