### PR TITLE
104 add path daily queststart with the challenge controller

### DIFF
--- a/public/css/error.css
+++ b/public/css/error.css
@@ -105,7 +105,7 @@ h1::before {
     justify-content: center;
     align-items: center;
     margin-top: 15px;
-    margin-left: 23%;
+    margin-left: 9%;
     display: inline-block;
     padding: 0.5rem 1rem;
     background: linear-gradient(135deg, #0b0d12, #2a3a4f, #d3d3d3);

--- a/public/css/error.css
+++ b/public/css/error.css
@@ -105,6 +105,7 @@ h1::before {
     justify-content: center;
     align-items: center;
     margin-top: 15px;
+    margin-left: 23%;
     display: inline-block;
     padding: 0.5rem 1rem;
     background: linear-gradient(135deg, #0b0d12, #2a3a4f, #d3d3d3);

--- a/public/css/register.css
+++ b/public/css/register.css
@@ -154,8 +154,32 @@ button:hover {
 .quest-button {
     display: block;
     width: 50%;
-    margin: 2rem auto 0 auto;
+    margin: 2rem auto 1rem auto;
+    text-align: justify-all;
 }
+
+.quest-link {
+    display: inline-block;
+    font-family: 'Cinzel', serif;
+    background: linear-gradient(135deg, #0b0d12, #2a3a4f, #d3d3d3);
+    color: #ffffff;
+    border: none;
+    padding: 0.8rem 1.2rem;
+    font-size: 1.1rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    border-radius: 5px;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+}
+
+.quest-link:hover {
+    background: linear-gradient(135deg, #0b0d12, #212c3e, #f5f5f5);
+    color: #a1a0a0;
+    transition: all 0.9s ease;
+}
+
 @keyframes horseRide {
     0% {
         left: -100px;
@@ -182,4 +206,28 @@ button:hover {
 .horse img {
     width: 100%;
     height: auto;
+}
+
+.quest-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+}
+
+.quest-table th, .quest-table td {
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+    align-items: center;
+}
+
+.quest-table th {
+    background: linear-gradient(135deg, #0b0d12, #2a3a4f, #d3d3d3);
+}
+
+.button-cell {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
 }

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -31,4 +31,9 @@ abstract class AbstractController
         return $this->templateProvider->get()->render($template, $params);
     }
 
+    public function redirect(string $path): string
+    {
+        header('Location: ' . $path, true, 302);
+        return '';
+    }
 }

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Lexgur\GondorGains\Controller;
+
+use Lexgur\GondorGains\Attribute\Path;
+use Lexgur\GondorGains\Exception\ForbiddenException;
+use Lexgur\GondorGains\Model\Challenge;
+use Lexgur\GondorGains\Repository\ChallengeModelRepository;
+use Lexgur\GondorGains\Service\CurrentUser;
+use Lexgur\GondorGains\TemplateProvider;
+
+#[Path('/daily-quest/start')]
+class CreateChallengeController extends AbstractController
+{
+    private CurrentUser $currentUser;
+
+    private ChallengeModelRepository $challengeRepository;
+
+    public function __construct(TemplateProvider $templateProvider, CurrentUser $currentUser, ChallengeModelRepository $challengeRepository)
+    {
+        parent::__construct($templateProvider);
+        $this->currentUser = $currentUser;
+        $this->challengeRepository = $challengeRepository;
+    }
+
+    public function __invoke(): string
+    {
+        if ($this->currentUser->isAnonymous()) {
+            throw new ForbiddenException();
+        }
+        if ($this->isPostRequest()) {
+            try {
+                $userId = (int) $_SESSION['id'];
+                $startedAt = new \DateTimeImmutable();
+                $challenge = new Challenge(
+                    userId: $userId,
+                    startedAt: $startedAt
+                );
+
+                $this->challengeRepository->save($challenge);
+
+                return $this->render('challenge_started.html.twig', [
+                    'challenge' => $challenge,
+                ]);
+            } catch (\Throwable) {
+                return $this->render('error.html.twig', [
+                    'code' => 403,
+                    'title' => 'Access restricted',
+                    'message' => 'You don\'t have permission to view this content.',
+                ]);
+            }
+        }
+
+        return $this->render('challenge_started.html.twig');
+    }
+}

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -47,7 +47,7 @@ class CreateChallengeController extends AbstractController
                 return $this->render('error.html.twig', [
                     'code' => 500,
                     'title' => 'Failed to start your challenge',
-                    'message' => $e->getMessage(),
+                    'message' => 'Our team has been notified. Please try again later.',
                 ]);
             }
         }

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Lexgur\GondorGains\Controller;
 
 use Lexgur\GondorGains\Attribute\Path;
@@ -13,7 +15,6 @@ use Lexgur\GondorGains\TemplateProvider;
 class CreateChallengeController extends AbstractController
 {
     private CurrentUser $currentUser;
-
     private ChallengeModelRepository $challengeRepository;
 
     public function __construct(TemplateProvider $templateProvider, CurrentUser $currentUser, ChallengeModelRepository $challengeRepository)
@@ -28,29 +29,28 @@ class CreateChallengeController extends AbstractController
         if ($this->currentUser->isAnonymous()) {
             throw new ForbiddenException();
         }
+
         if ($this->isPostRequest()) {
             try {
-                $userId = (int) $_SESSION['id'];
+                $userId = (int)$_SESSION['id'];
                 $startedAt = new \DateTimeImmutable();
+
                 $challenge = new Challenge(
                     userId: $userId,
                     startedAt: $startedAt
                 );
-
+                $challenge->setCompletedAt(new \DateTimeImmutable());
                 $this->challengeRepository->save($challenge);
-
-                return $this->render('challenge_started.html.twig', [
-                    'challenge' => $challenge,
-                ]);
-            } catch (\Throwable) {
+                header('Location: /quests');
+                return '';
+            } catch (\Throwable $e) {
                 return $this->render('error.html.twig', [
-                    'code' => 403,
-                    'title' => 'Access restricted',
-                    'message' => 'You don\'t have permission to view this content.',
+                    'code' => 500,
+                    'title' => 'Failed to start your challenge',
+                    'message' => $e->getMessage(),
                 ]);
             }
         }
-
         return $this->render('challenge_started.html.twig');
     }
 }

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lexgur\GondorGains\Controller;
 
 use Lexgur\GondorGains\Attribute\Path;
-use Lexgur\GondorGains\Exception\BadRequestException;
 use Lexgur\GondorGains\Exception\ForbiddenException;
 use Lexgur\GondorGains\Model\Challenge;
 use Lexgur\GondorGains\Repository\ChallengeModelRepository;
@@ -32,25 +31,23 @@ class CreateChallengeController extends AbstractController
         }
 
         if ($this->isPostRequest()) {
-            if ($_POST['action'] === 'challenge-complete') {
-                try {
-                    $user = $this->currentUser->getUser();
-                    $userId = $user->getUserId();
-                    $startedAt = new \DateTimeImmutable();
+            if ('challenge-complete' === $_POST['action']) {
+                $user = $this->currentUser->getUser();
+                $userId = $user->getUserId();
+                $startedAt = new \DateTimeImmutable();
 
-                    $challenge = new Challenge(
-                        userId: $userId,
-                        startedAt: $startedAt
-                    );
-                    $challenge->setCompletedAt(new \DateTimeImmutable());
-                    $this->challengeRepository->save($challenge);
-                    header('Location: /quests');
-                    return '';
-                } catch (\Throwable) {
-                    throw new BadRequestException();
-                }
+                $challenge = new Challenge(
+                    userId: $userId,
+                    startedAt: $startedAt
+                );
+                $challenge->setCompletedAt(new \DateTimeImmutable());
+                $this->challengeRepository->save($challenge);
+                header('Location: /quests');
+
+                return '';
             }
         }
+
         return $this->render('challenge_started.html.twig');
     }
 }

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -42,9 +42,7 @@ class CreateChallengeController extends AbstractController
                 );
                 $challenge->setCompletedAt(new \DateTimeImmutable());
                 $this->challengeRepository->save($challenge);
-                header('Location: /quests');
-
-                return '';
+                $this->redirect('/quests');
             }
         }
 

--- a/src/Controller/CreateChallengeController.php
+++ b/src/Controller/CreateChallengeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lexgur\GondorGains\Controller;
 
 use Lexgur\GondorGains\Attribute\Path;
+use Lexgur\GondorGains\Exception\BadRequestException;
 use Lexgur\GondorGains\Exception\ForbiddenException;
 use Lexgur\GondorGains\Model\Challenge;
 use Lexgur\GondorGains\Repository\ChallengeModelRepository;
@@ -31,24 +32,23 @@ class CreateChallengeController extends AbstractController
         }
 
         if ($this->isPostRequest()) {
-            try {
-                $userId = (int)$_SESSION['id'];
-                $startedAt = new \DateTimeImmutable();
+            if ($_POST['action'] === 'challenge-complete') {
+                try {
+                    $user = $this->currentUser->getUser();
+                    $userId = $user->getUserId();
+                    $startedAt = new \DateTimeImmutable();
 
-                $challenge = new Challenge(
-                    userId: $userId,
-                    startedAt: $startedAt
-                );
-                $challenge->setCompletedAt(new \DateTimeImmutable());
-                $this->challengeRepository->save($challenge);
-                header('Location: /quests');
-                return '';
-            } catch (\Throwable $e) {
-                return $this->render('error.html.twig', [
-                    'code' => 500,
-                    'title' => 'Failed to start your challenge',
-                    'message' => 'Our team has been notified. Please try again later.',
-                ]);
+                    $challenge = new Challenge(
+                        userId: $userId,
+                        startedAt: $startedAt
+                    );
+                    $challenge->setCompletedAt(new \DateTimeImmutable());
+                    $this->challengeRepository->save($challenge);
+                    header('Location: /quests');
+                    return '';
+                } catch (\Throwable) {
+                    throw new BadRequestException();
+                }
             }
         }
         return $this->render('challenge_started.html.twig');

--- a/src/Controller/LoginUserController.php
+++ b/src/Controller/LoginUserController.php
@@ -52,11 +52,9 @@ class LoginUserController extends AbstractController
                 PasswordVerifier::verify($password, $registeredUser->getUserPassword());
 
                 $this->session->start($registeredUser);
-                header('Location: /dashboard');
-                return '';
+                $this->redirect('/dashboard');
             } catch (UserNotFoundException) {
-                header('Location: /register', true, 302);
-                return '';
+                $this->redirect('/register');
             } catch (\Throwable) {
                 return $this->render('login.html.twig', [
                     'error' => 'You don\'t have permission to view this content.',

--- a/src/Controller/LogoutUserController.php
+++ b/src/Controller/LogoutUserController.php
@@ -30,8 +30,7 @@ class LogoutUserController extends AbstractController
             }
 
             $this->session->destroy();
-            header('Location: /login', true, 302);
-            return '';
+            $this->redirect('/login');
         } catch (\Throwable) {
             return $this->render('error.html.twig', [
                 'code' => 403,

--- a/src/Repository/ChallengeModelRepository.php
+++ b/src/Repository/ChallengeModelRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lexgur\GondorGains\Repository;
 
+use Exception;
 use Lexgur\GondorGains\Exception\ChallengeNotFoundException;
 use Lexgur\GondorGains\Model\Challenge;
 use PDO;
@@ -50,6 +51,7 @@ class ChallengeModelRepository extends BaseRepository implements ChallengeModelR
         ]);
     }
 
+    /** @return Challenge[] */
     public function fetchAllChallenges(): array
     {
         $statement = $this->connection->connect()->prepare('SELECT * FROM `challenges`');

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -1,0 +1,15 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Quest Started{% endblock %}
+
+{% block content %}
+    <div class="form-container">
+        <h1>Quest Started!</h1>
+        <p>Started at: {{ challenge.startedAt|date("Y-m-d H:i:s") }}</p>
+
+        <form method="POST" action="/daily-quest/complete">
+            <input type="hidden" name="challenge_id" value="{{ challenge.challengeId }}">
+            <button type="submit">MARK AS DONE</button>
+        </form>
+    </div>
+{% endblock %}

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -11,7 +11,7 @@
             <input type="hidden" name="user_id" value="{{ challenge.user_id }}">
             <input type="hidden" name="started_at" value="{{ challenge.started_at|date("Y-m-d H:i:s") }}">
             <input type="hidden" name="completed_at" value="{{ challenge.completed_at|date("Y-m-d H:i:s") }}">
-            <button type="submit">MARK AS DONE</button>
+            <button type="submit" value="challenge-complete" name="action">MARK AS DONE</button>
         </form>
     </div>
 {% endblock %}

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -7,8 +7,10 @@
         <h1>Quest Started!</h1>
         <p>Started at: {{ challenge.startedAt|date("Y-m-d H:i:s") }}</p>
 
-        <form method="POST" action="/daily-quest/complete">
-            <input type="hidden" name="challenge_id" value="{{ challenge.challengeId }}">
+        <form method="POST" action="/daily-quest/start">
+            <input type="hidden" name="user_id" value="{{ challenge.user_id }}">
+            <input type="hidden" name="started_at" value="{{ challenge.started_at|date("Y-m-d H:i:s") }}">
+            <input type="hidden" name="completed_at" value="{{ challenge.completed_at|date("Y-m-d H:i:s") }}">
             <button type="submit">MARK AS DONE</button>
         </form>
     </div>

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="form-container">
-        <p>Started at: {{ challenge.startedAt|date("Y-m-d H:i:s") }}</p>
+        <p>Let's begin, Gondorian!</p>
 
         <form method="POST" action="/daily-quest/start">
             <button type="submit" value="challenge-complete" name="action">MARK AS DONE</button>

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -8,9 +8,6 @@
         <p>Started at: {{ challenge.startedAt|date("Y-m-d H:i:s") }}</p>
 
         <form method="POST" action="/daily-quest/start">
-            <input type="hidden" name="user_id" value="{{ challenge.user_id }}">
-            <input type="hidden" name="started_at" value="{{ challenge.started_at|date("Y-m-d H:i:s") }}">
-            <input type="hidden" name="completed_at" value="{{ challenge.completed_at|date("Y-m-d H:i:s") }}">
             <button type="submit" value="challenge-complete" name="action">MARK AS DONE</button>
         </form>
     </div>

--- a/templates/challenge_started.html.twig
+++ b/templates/challenge_started.html.twig
@@ -1,10 +1,9 @@
 {% extends "base.html.twig" %}
 
-{% block title %}Quest Started{% endblock %}
+{% block title %}Quest Started!{% endblock %}
 
 {% block content %}
     <div class="form-container">
-        <h1>Quest Started!</h1>
         <p>Started at: {{ challenge.startedAt|date("Y-m-d H:i:s") }}</p>
 
         <form method="POST" action="/daily-quest/start">

--- a/templates/quests.html.twig
+++ b/templates/quests.html.twig
@@ -7,21 +7,38 @@
         <header class="welcome-message">
             <h2>{{ message }}</h2>
         </header>
+
         {% if challenges is not empty %}
-            <ul>
+            <table class="quest-table">
+                <thead>
+                <tr>
+                    <th>Quest</th>
+                    <th>Started At</th>
+                    <th>Completed At</th>
+                    <th>Action</th>
+                </tr>
+                </thead>
+                <tbody>
                 {% for challenge in challenges %}
-                    <li>
-                        Quest #{{ challenge.id }}<br>
-                        Started at: {{ challenge.started_at }}<br>
-                        Completed at: {{ challenge.completed_at }}<br>
-                        <a href="/quests/view/{{ challenge.id }}" class="btn">View</a>
-                    </li>
+                    <tr>
+                        <td>Quest #{{ loop.index }}</td>
+                        <td>{{ challenge.started_at }}</td>
+                        <td>{{ challenge.completed_at }}</td>
+                        <td>
+                            <div class="button-cell">
+                                <a href="/daily-quest/{{ challenge.id }}/" class="quest-link">View</a>
+                            </div>
+                        </td>
+                    </tr>
                 {% endfor %}
-            </ul>
+                </tbody>
+            </table>
         {% else %}
             <p>No completed quests yet.</p>
         {% endif %}
+
         {% include "quote.html.twig" %}
+
         <button class="quest-button" onclick="window.location.href='{{ quest }}';">Start your daily quest</button>
     </div>
 {% endblock %}

--- a/tests/CreateChallengeWebTest.php
+++ b/tests/CreateChallengeWebTest.php
@@ -12,6 +12,15 @@ use Lexgur\GondorGains\Service\Session;
 
 class CreateChallengeWebTest extends WebTestCase
 {
+
+    private Container $container;
+
+    private UserModelRepository $userModelRepository;
+
+    private Session $session;
+
+    private Connection $database;
+
     public function setUp(): void
     {
         $_ENV['IS_WEB_TEST'] = 'true';

--- a/tests/CreateChallengeWebTest.php
+++ b/tests/CreateChallengeWebTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lexgur\GondorGains\Tests;
+
+use Lexgur\GondorGains\Connection;
+use Lexgur\GondorGains\Container;
+use Lexgur\GondorGains\Model\User;
+use Lexgur\GondorGains\Repository\UserModelRepository;
+use Lexgur\GondorGains\Service\Session;
+
+class CreateChallengeWebTest extends WebTestCase
+{
+    public function setUp(): void
+    {
+        $_ENV['IS_WEB_TEST'] = 'true';
+
+        $config = require __DIR__.'/../config.php';
+        $this->container = new Container($config);
+        $this->session = $this->container->get(Session::class);
+        $this->database = $this->container->get(Connection::class);
+        $this->userModelRepository = $this->container->get(UserModelRepository::class);
+
+        parent::setUp();
+    }
+
+    public function tearDown(): void
+    {
+        $this->database->connect()->exec('DELETE FROM challenges');
+        $this->session->destroy();
+    }
+
+    public function testChallengePageAccessible(): void
+    {
+        $this->markTestSkipped('Just like in Quests the sessions are not handled properly');
+        $username = 'testSuccess';
+        $email = 'testSuccess@test.com';
+        $password = 'testSuccess123';
+        $user = new User($username, $email, $password);
+        $savedUser = $this->userModelRepository->save($user);
+        $this->session->start($savedUser);
+
+        $response = $this->request('GET', '/daily-quest/start');
+
+        $this->assertEquals(200, http_response_code());
+        $this->assertStringContainsString('List of completed quests, Gondorian', $response);
+    }
+
+    public function testAnonymousAccessDenied(): void
+    {
+        $response = $this->request('GET', '/daily-quest/start');
+        $statusCode = http_response_code();
+
+        $this->assertStringContainsString('<title>Access restricted - Gondor Gains</title>', $response);
+        $this->assertEquals(403, $statusCode);
+    }
+
+}

--- a/tests/CreateChallengeWebTest.php
+++ b/tests/CreateChallengeWebTest.php
@@ -40,22 +40,6 @@ class CreateChallengeWebTest extends WebTestCase
         $this->session->destroy();
     }
 
-    public function testChallengePageAccessible(): void
-    {
-        $this->markTestSkipped('Just like in Quests the sessions are not handled properly');
-        $username = 'testSuccess';
-        $email = 'testSuccess@test.com';
-        $password = 'testSuccess123';
-        $user = new User($username, $email, $password);
-        $savedUser = $this->userModelRepository->save($user);
-        $this->session->start($savedUser);
-
-        $response = $this->request('GET', '/daily-quest/start');
-
-        $this->assertEquals(200, http_response_code());
-        $this->assertStringContainsString('List of completed quests, Gondorian', $response);
-    }
-
     public function testAnonymousAccessDenied(): void
     {
         $response = $this->request('GET', '/daily-quest/start');
@@ -64,5 +48,4 @@ class CreateChallengeWebTest extends WebTestCase
         $this->assertStringContainsString('<title>Access restricted - Gondor Gains</title>', $response);
         $this->assertEquals(403, $statusCode);
     }
-
 }


### PR DESCRIPTION
# What was done?

A simple way to start and finish a new Challenge/Quest was added. Currently holding nothing but the button to be done with it.

![image](https://github.com/user-attachments/assets/8e2f920a-6f84-4771-9b7e-78d5220b89dd)

Once 'Mark as done' is pressed, the user is taken back to the list of users, path '/quests', where each completed quest is displayed.

![image](https://github.com/user-attachments/assets/e29c6abf-98e0-4ced-83b7-be39f33fe79c)

# Why was it done?

According to the flow, that is the correct pathing and the needed functionality for the project. Now the user can see the quests they have completed, and later, with the ability to view each individually.

# Tests 

Like all the controllers thus far, I am able only to test anonymous access, which results thrown a 403 error.
