### PR TITLE
120 Fixed code coverage: Challenge.php

### DIFF
--- a/src/Model/Challenge.php
+++ b/src/Model/Challenge.php
@@ -34,11 +34,6 @@ class Challenge
         return $this->userId;
     }
 
-    public function setUserId(int $userId): void
-    {
-        $this->userId = $userId;
-    }
-
     public function getStartedAt(): DateTimeInterface
     {
         return $this->startedAt;

--- a/tests/ChallengeTest.php
+++ b/tests/ChallengeTest.php
@@ -25,6 +25,19 @@ class ChallengeTest extends TestCase
         $this->assertEquals($completedAt, $challenge->getCompletedAt());
     }
 
+    public function testSetUserIdCorrectlySetsUserId(): void
+    {
+        $userId = 1;
+        $newUserId = 42;
+        $startedAt = new \DateTime('2025-05-06');
+        $completedAt = new \DateTime('2025-05-07');
+        $challenge = new Challenge($userId, $startedAt, $completedAt);
+
+        $challenge->setUserId($newUserId);
+
+        $this->assertEquals($newUserId, $challenge->getUserId());
+    }
+
     public function testConstructorThrowsTypeErrorWhenInvalidArgumentIsProvided(): void
     {
 

--- a/tests/ChallengeTest.php
+++ b/tests/ChallengeTest.php
@@ -25,19 +25,6 @@ class ChallengeTest extends TestCase
         $this->assertEquals($completedAt, $challenge->getCompletedAt());
     }
 
-    public function testSetUserIdCorrectlySetsUserId(): void
-    {
-        $userId = 1;
-        $newUserId = 42;
-        $startedAt = new \DateTime('2025-05-06');
-        $completedAt = new \DateTime('2025-05-07');
-        $challenge = new Challenge($userId, $startedAt, $completedAt);
-
-        $challenge->setUserId($newUserId);
-
-        $this->assertEquals($newUserId, $challenge->getUserId());
-    }
-
     public function testConstructorThrowsTypeErrorWhenInvalidArgumentIsProvided(): void
     {
 


### PR DESCRIPTION
# What was done:

The setUserId method is now removed from Challenge.php completely.

# Why was it done?

It was an unnecessary behaviour for the application; I will not give the same challenge to a different user.

As shown by the test coverage of PHPUnit, Challenge.php is now fully covered: 

![image](https://github.com/user-attachments/assets/b8e2edc1-2d59-4cf2-b87d-218376d84a46)
