### PR TITLE
121 Fixed code coverage: ExerciseModelRepository.php

### DIFF
--- a/tests/ExerciseModelRepositoryTest.php
+++ b/tests/ExerciseModelRepositoryTest.php
@@ -112,12 +112,27 @@ class ExerciseModelRepositoryTest extends TestCase
         $insertedExercise->setName('NewTests');
         $insertedExercise->setDescription('new-test');
         $insertedExercise->setMuscleGroup(MuscleGroup::ARMS);
+        $this->repository->save($insertedExercise);
 
         $this->assertNotNull($insertedExercise->getExerciseId());
         $this->assertEquals('NewTests', $insertedExercise->getName());
         $this->assertEquals('new-test', $insertedExercise->getDescription());
         $this->assertEquals(MuscleGroup::ARMS, $insertedExercise->getMuscleGroup());
     }
+
+    public function testInsertIsCalledWhenExerciseIdIsNull(): void
+    {
+        $exercise = new Exercise(
+            name: 'Test',
+            muscleGroup: MuscleGroup::CHEST,
+            description: 'good exercise',
+            exerciseId: null
+        );
+        $insertedExercise = $this->repository->save($exercise);
+
+        $this->assertNotNull($insertedExercise->getExerciseId());
+    }
+
 
     public function testSuccessfulExerciseDeletion(): void
     {


### PR DESCRIPTION
# What was done?

The behaviour of if id = null has been tested with a new test in ExerciseModelRepositoryTest.php 'testInsertIsCalledWhenExerciseIdIsNull'.

# Why was it done?

To see how the application will behave when this happens, to fix the test coverage.

Here's an example of the updated test coverage:

![image](https://github.com/user-attachments/assets/f15b897f-c131-4683-a1b2-726f1f52a1b2)

