### PR TITLE
126 Fixed code coverage: ClassFinder.php

### DIFF
--- a/src/ClassFinder.php
+++ b/src/ClassFinder.php
@@ -90,6 +90,10 @@ class ClassFinder
         foreach ($phpFiles as $file) {
                 $path = $file->getPathname();
                 $className = $this->getFullClassName($path);
+
+                if ($className === null) {
+                    continue;
+                }
                 $reflectionClass = new \ReflectionClass($className);
 
                 if ($condition($reflectionClass, $className)) {

--- a/tests/ClassFinderBadTest/NoMatchFile.php
+++ b/tests/ClassFinderBadTest/NoMatchFile.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lexgur\GondorGains\Tests\ClassFinderBadTest;
+
+function helper(): true
+{
+    return true;
+}

--- a/tests/ClassFinderTest.php
+++ b/tests/ClassFinderTest.php
@@ -113,6 +113,22 @@ class ClassFinderTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testGetFullClassNameWithNonExistentPathReturnsNull(): void
+    {
+        $path = 'NoPathLikeThis';
+        $result = $this->classFinder->getFullClassName($path);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetFullClassNameReturnsNullWhenNoClassFound(): void
+    {
+        $path = __DIR__ . '/ClassFinderBadTest/NoMatchFile.php';
+        $result = $this->classFinder->getFullClassName($path);
+
+        $this->assertNull($result);
+    }
+
     /** @return  array<int, list<list<string>|string>> */
     public static function provideTestFindClassesInNamespaceData(): array
     {


### PR DESCRIPTION
# What was done?
There was no handling if $className does not contain any of the matching types, it would break all of the ClassFinder.php.

So a safety guard was added to skip the class.

Then line 79 would work correctly and return null if that is the case. NoMatchFile.php was added just for that reason, to test that behaviour.

# Why was it done? 

It was the only way to correctly cover ClassFinder.php with tests.

As now shown:

![image](https://github.com/user-attachments/assets/0a484fed-b066-4fd9-95e7-74faeb4d7c8a)
