### PR TITLE
124 Fixed: code coverage ScriptNameValidator.php

### DIFF
--- a/tests/ScriptNameValidatorTest.php
+++ b/tests/ScriptNameValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lexgur\GondorGains\Tests;
 
+use Lexgur\GondorGains\Exception\IncorrectScriptNameException;
 use Lexgur\GondorGains\Validation\ScriptNameValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +26,13 @@ class ScriptNameValidatorTest extends TestCase {
         $this->assertEquals($expected, $actual);
     }
 
+    #[DataProvider('provideInvalidNamespaceData')]
+    public function testInvalidNamespacesThrowException(string $scriptClassName): void
+    {
+        $this->expectException(IncorrectScriptNameException::class);
+        $this->validator->validate($scriptClassName);
+    }
+
     /** @return array<array{string, int}> */
     public static function provideTestNamespaceRegexData(): array
     {
@@ -38,4 +46,17 @@ class ScriptNameValidatorTest extends TestCase {
         ];
     }
 
+    public static function provideInvalidNamespaceData(): array
+    {
+        return [
+            [''],
+            ['123Invalid\Namespace'],
+            ['InvalidNamespace!'],
+            ['Namespace with spaces'],
+            ['\\'],
+            ['/'],
+            ['\\\\invalid\\path\\'],
+            ['Invalid/Namespace/'],
+        ];
+    }
 }


### PR DESCRIPTION
# What was done?
ScriptNameValidator is now fully test-covered.

Added InvalidNamespaceData and a test to see if the correct exception is thrown.

# Why was it done? 

Previously, not all cases were covered by a test.
![image](https://github.com/user-attachments/assets/8fc3212b-f1e8-4bdb-b4a3-abbd5f5b279b)
