### PR TITLE
129 Fixed code coverage Script.php

### DIFF
--- a/tests/Script/ScriptNotInstanceOfScriptInterface.php
+++ b/tests/Script/ScriptNotInstanceOfScriptInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lexgur\GondorGains\Tests\Script;
+
+class ScriptNotInstanceOfScriptInterface
+{
+    public function run(): int
+    {
+        echo 'Oopses!';
+
+        return 0;
+    }
+
+}

--- a/tests/ScriptTest.php
+++ b/tests/ScriptTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lexgur\GondorGains\Tests;
 
 use Lexgur\GondorGains\Exception\IncorrectScriptNameException;
+use Lexgur\GondorGains\Exception\ScriptFailedToRunException;
 use Lexgur\GondorGains\Script;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -68,6 +69,14 @@ class ScriptTest extends TestCase
         $this->script->run($scriptClassName);
     }
 
+    public function testScripFailedToRunExceptionIsThrownWithNonExistentScript(): void
+    {
+        $this->expectException(ScriptFailedToRunException::class);
+
+        $scriptClassName = 'Lexgur/GondorGains/Tests/Script/ScriptNotInstanceOfScriptInterface';
+        $this->script->run($scriptClassName);
+    }
+
     /** @return array<array{string}> */
     public static function provideTestScriptFailedToRunExceptionData(): array
     {
@@ -75,7 +84,7 @@ class ScriptTest extends TestCase
             ['LexgurGondorGainsTestsScriptFailedScript'],
             ['Lexgur/GondorGains/Tests/Script//FailedScript'],
             ['//Lexgur/GondorGains/Tests/Script/FailedScript'],
+            ['/\Lexgur/GondorGains\\Tests/Script\\FailedScript'],
         ];
     }
-
 }


### PR DESCRIPTION
#129 

#What was done? 

One test added for the ScriptFailedToRunException, and one more case to get the 'mixed separators' IncorrectScriptNameException.

# Why was it done?

Not all the behaviour of the class was tested.

Image :

![image](https://github.com/user-attachments/assets/59328dd5-7b97-47e5-852a-5fa0483a861a)
